### PR TITLE
Fix: Typo in README (casing error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ source devel/setup.bash
 ## Getting Started
 ```bash
 # visualize raw LiDAR & encoder data and convert ROS bag to TXT
- roslaunch Motor_LiDAR_Calib visualization.launch 
+ roslaunch motor_lidar_calib visualization.launch 
 
 #  convert ROS bag to TXT NQZ
  python scripts/convertTXT2NP.py 


### PR DESCRIPTION
Hi all,

Here is a casing error in README.md, which may cause the issue below
```bash
RLException: [visualization.launch] is neither a launch file in package [Motor_LiDAR_Calib] nor is [Motor_LiDAR_Calib] a launch file name
The traceback for the exception was written to the log file
```


Best Regards
------------------
Louis Li