### PR TITLE
Fix: Missing intensity information

### DIFF
--- a/src/rot_radar_lidar_node.cpp
+++ b/src/rot_radar_lidar_node.cpp
@@ -467,7 +467,7 @@ void saveLiDARRotorFile(std::string filename)
 
       // save to a data log
       // Initial (x y z) Raw (x y z) intensity angle time
-      fprintf(file,"%lf %lf %lf %lf %lf %lf %d %lf %lf \n", pt_trans.x, pt_trans.y, pt_trans.z, point.x, point.y, point.z, rotAngular, tmpTime);
+      fprintf(file,"%lf %lf %lf %lf %lf %lf %d %lf %lf \n", pt_trans.x, pt_trans.y, pt_trans.z, point.x, point.y, point.z, static_cast<int>(point.intensity), rotAngular, tmpTime);
     }
   }
 


### PR DESCRIPTION
Hi Jianping,

Intensity information is lost here. 

https://github.com/kafeiyin00/LiMo-Calib/blob/36b7ea7d7ddd9dae86e59a759b9a77346696d64e/src/rot_radar_lidar_node.cpp#L470

Comparison of before and after the fix below:
![Screenshot from 2025-07-01 17-09-01](https://github.com/user-attachments/assets/4f69563b-4eb5-41ea-8f54-f01fe2fc3958)

Point cloud after fixing intensity:
![Screenshot from 2025-07-01 17-07-54](https://github.com/user-attachments/assets/c8d699c1-5a51-4afb-904e-588ddc8b8404)


Best Regards
------------------
Louis Li